### PR TITLE
Derive arbitrary if fuzzing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default = []
 nightly = []
 serde = ["dep:serde", "serde-big-array"]
 numtraits = ["num-integer", "num-traits"]
+fuzzing = ["arbitrary"]
 
 [dependencies]
 num-integer = { version = "0.1.45", optional = true, default-features = false }
@@ -26,6 +27,7 @@ num-traits = { version = "0.2.15", optional = true, default-features = false }
 serde = { version = "1.0.152", features = ["derive"], optional = true, default-features = false }
 serde-big-array = { version = "0.4.1", optional = true, default-features = false }
 rand = { version = "0.8.5", features = ["min_const_gen", "small_rng", "std_rng"], optional = true, default-features = false }
+arbitrary = { version = "1.3.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/src/bint/mod.rs
+++ b/src/bint/mod.rs
@@ -32,6 +32,9 @@ use core::default::Default;
 
 use core::iter::{Iterator, Product, Sum};
 
+#[cfg(feature = "fuzzing")]
+use arbitrary::Arbitrary;
+
 macro_rules! mod_impl {
 	($BUint: ident, $BInt: ident, $Digit: ident) => {
 		/// Big signed integer type, of fixed size which must be known at compile time.
@@ -47,6 +50,7 @@ macro_rules! mod_impl {
 		#[allow(clippy::derive_hash_xor_eq)]
 		#[derive(Clone, Copy, Hash)]
 		#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+		#[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
 		pub struct $BInt<const N: usize> {
 			pub(crate) bits: $BUint<N>,
 		}
@@ -134,18 +138,18 @@ macro_rules! mod_impl {
 					self.bits
 				}
 			}
-			
+
 			#[doc = doc::pow!(I 256)]
 			#[must_use = doc::must_use_op!()]
 			#[inline]
 			pub const fn pow(self, exp: ExpType) -> Self {
 				#[cfg(debug_assertions)]
 				return option_expect!(self.checked_pow(exp), errors::err_msg!("attempt to calculate power with overflow"));
-				
+
 				#[cfg(not(debug_assertions))]
 				self.wrapping_pow(exp)
 			}
-			
+
 			crate::nightly::const_fns! {
 				#[doc = doc::div_euclid!(I)]
 				#[must_use = doc::must_use_op!()]

--- a/src/buint/mod.rs
+++ b/src/buint/mod.rs
@@ -8,7 +8,7 @@ use crate::ExpType;
 use core::mem::MaybeUninit;
 
 #[cfg(feature = "serde")]
-use ::{
+use {
     serde::{Deserialize, Serialize},
     serde_big_array::BigArray,
 };
@@ -16,6 +16,9 @@ use ::{
 use core::default::Default;
 
 use core::iter::{Iterator, Product, Sum};
+
+#[cfg(feature = "fuzzing")]
+use arbitrary::Arbitrary;
 
 macro_rules! mod_impl {
 	($BUint: ident, $BInt: ident, $Digit: ident) => {
@@ -33,6 +36,7 @@ macro_rules! mod_impl {
 		#[allow(clippy::derive_hash_xor_eq)]
 		#[derive(Clone, Copy, Hash)]
 		#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+		#[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
 		pub struct $BUint<const N: usize> {
 			#[cfg_attr(feature = "serde", serde(with = "BigArray"))]
 			pub(crate) digits: [$Digit; N],
@@ -671,11 +675,11 @@ macro_rules! mod_impl {
 
 crate::main_impl!(mod_impl);
 
-mod consts;
 mod bigint_helpers;
 mod cast;
 mod checked;
 mod cmp;
+mod consts;
 mod convert;
 mod endian;
 mod fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
     )
 )]
 #![doc = include_str!("../README.md")]
-#![no_std]
+#![cfg_attr(not(feature = "fuzzing"), no_std)]
 
 #[macro_use]
 extern crate alloc;


### PR DESCRIPTION
Introduced "fuzzing" feature to enable struct-aware fuzzing of the types introduced by `bnum` crate.

Unfortunately `arbitrary` works only for `std` at the moment.

More details on `arbitrary`:
https://github.com/rust-fuzz/arbitrary
https://docs.rs/arbitrary/latest/arbitrary/