### PR TITLE
Add minimum rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/isaacholt100/bnum"
 readme = "README.md"
 keywords = ["uint", "int", "bignum", "maths", "arbitrary"]
 categories = ["algorithms", "mathematics", "cryptography", "no-std"]
+rust-version = "1.65"
 
 exclude = ["src/float/*", "src/tests", "TODO.txt", "lit-parser/*"] # TODO: make sure to include these when they are ready
 


### PR DESCRIPTION
Hi, are you interested in adding the minimum rust version to `Cargo.toml`?
That way people with a dependency on the crate (direct or transitive) get an error message that is a bit more helpful.
Currently, if you compile with pre-1.65 Rust, you just get a bunch of errors like this:
> no method named `cast_mut` found for raw pointer `*const [u16; N]` in the current scope

Only downside is that it has to be kept in sync with the code to be useful.