### PR TITLE
add digits_mut to buint

### DIFF
--- a/src/buint/mod.rs
+++ b/src/buint/mod.rs
@@ -484,6 +484,13 @@ macro_rules! mod_impl {
                 &self.digits
             }
 
+            /// Returns the digits stored in `self` as a mutable array. Digits are little endian (least significant digit first).
+            #[must_use]
+            #[inline(always)]
+            pub fn digits_mut(&mut self) -> &mut [$Digit; N] {
+                &mut self.digits
+            }
+
             /// Creates a new unsigned integer from the given array of digits. Digits are stored as little endian (least significant digit first).
             #[must_use]
             #[inline(always)]


### PR DESCRIPTION
Allow direct access to the digits for custom digit twiddling hacks, without needing to copy the whole number.