### PR TITLE
Fix `to_radix_be`, `to_radix_le` and `to_str_radix` documentation

### DIFF
--- a/src/bint/radix.rs
+++ b/src/bint/radix.rs
@@ -151,10 +151,6 @@ macro_rules! radix {
 
             /// Returns the integer's underlying representation as an unsigned integer in the given base in little-endian digit order.
             ///
-            /// # Panics
-            ///
-            /// This function panics if `radix` is not in the range from 2 to 256 inclusive.
-            ///
             /// For examples, see the
             #[doc = concat!("[`to_radix_le`](crate::", stringify!($BUint), "::to_radix_le) method documentation for [`", stringify!($BUint), "`](crate::", stringify!($BUint), ").")]
             #[inline]

--- a/src/buint/radix.rs
+++ b/src/buint/radix.rs
@@ -433,10 +433,6 @@ macro_rules! radix {
 
             /// Returns the integer as a string in the given radix.
             ///
-            /// # Panics
-            ///
-            /// This function panics if `radix` is not in the range from 2 to 36 inclusive.
-            ///
             /// # Examples
             ///
             /// ```
@@ -461,10 +457,6 @@ macro_rules! radix {
             }
 
             /// Returns the integer in the given base in big-endian digit order.
-            ///
-            /// # Panics
-            ///
-            /// This function panics if `radix` is not in the range from 2 to 256 inclusive.
             ///
             /// ```
             /// use bnum::types::U512;


### PR DESCRIPTION
The docs say that it panics for some range, but that doesn't seem to be the case to me.
A test would probably be good, but I'm not sure where to put it and how to write it.