### PR TITLE
Add as_bits & as_bits_mut Methods To BInt

### DIFF
--- a/src/bint/mod.rs
+++ b/src/bint/mod.rs
@@ -368,6 +368,20 @@ macro_rules! mod_impl {
             pub const fn to_bits(self) -> $BUint<N> {
                 self.bits
             }
+
+            /// This simply returns a reference to the underlying representation of the integer in two's complement, as an unsigned integer.
+            #[must_use]
+            #[inline(always)]
+            pub const fn as_bits(&self) -> &$BUint<N> {
+                &self.bits
+            }
+
+            /// This simply returns a mutable reference to the underlying representation of the integer in two's complement, as an unsigned integer.
+            #[must_use]
+            #[inline(always)]
+            pub const fn as_bits_mut(&mut self) -> &mut $BUint<N> {
+                &mut self.bits
+            }
         }
 
         impl<const N: usize> Default for $BInt<N> {


### PR DESCRIPTION
The purpose of these methods is to provide mutable access to `BUInt` to operate `set_bit` without copying the `BInt`, so alternatively `set_bit` could be directly implemented on `BInt`.

This code is in my hot path, gotta do less copying bints... karatsuba would also help a bit but basically I need to just write better code.  To be exact, I'm doing a lot of square roots and the algorithm is just guess-and-check each bit.  The real solution is for me to do fewer square roots.

You can make `as_bits_mut` non-const if you don't want to increase the MSRV.