### PR TITLE
Made BUint::<N>::BYTES_USIZE pub in buint/endian.rs

### DIFF
--- a/src/buint/endian.rs
+++ b/src/buint/endian.rs
@@ -285,7 +285,7 @@ macro_rules! endian {
                 Self::from_le_bytes(bytes)
             }
 
-            pub(crate) const BYTES_USIZE: usize = N * digit::$Digit::BYTES as usize;
+            pub const BYTES_USIZE: usize = N * digit::$Digit::BYTES as usize;
         }
     };
 }


### PR DESCRIPTION
BYTES_USIZE must be public to use to_be_bytes and from_be_bytes for BUint<N> (with generic N).

Use case examples:
https://github.com/estevaopbs/bitcoin-rs/blob/main/src/ecc/elliptic_curve.rs
https://github.com/estevaopbs/bitcoin-rs/blob/main/src/ecc/private_key.rs
https://github.com/estevaopbs/bitcoin-rs/blob/main/src/ecc/signature.rs
https://github.com/estevaopbs/bitcoin-rs/blob/main/src/ser/base58.rs