### PR TITLE
perf(wasm32): u32 schoolbook digits in overflowing_mul to avoid __multi3 libcalls

### DIFF
--- a/src/integer/overflowing.rs
+++ b/src/integer/overflowing.rs
@@ -127,8 +127,23 @@ impl<const S: bool, const N: usize, const B: usize, const OM: u8> Integer<S, N, 
             };
         }
         // TODO: implement a faster multiplication algorithm for large values of `N`
-        let a = self.to_digits::<u128>();
-        let b = rhs.to_digits::<u128>();
+        //
+        // Select the schoolbook partial-product width by target. wasm32 has no
+        // 128-bit multiply, so a `u128` partial product lowers to a `__multi3`
+        // software libcall per digit — the dominant cost of wide-integer multiply
+        // on wasm. Splitting into `u32` digits makes each partial product a single
+        // `u32 * u32 -> u64` (one `i64.mul`, no libcall). The result is identical:
+        // `to_digits::<D>` reinterprets the same N-byte two's-complement operand,
+        // and the low-N-byte product (and whether it overflows the width) is a
+        // property of the true product, not of the accumulation digit width. Off
+        // wasm32, `u128` keeps the native path (with a hardware 128-bit multiply)
+        // unchanged.
+        #[cfg(target_arch = "wasm32")]
+        type MulDigit = u32;
+        #[cfg(not(target_arch = "wasm32"))]
+        type MulDigit = u128;
+        let a = self.to_digits::<MulDigit>();
+        let b = rhs.to_digits::<MulDigit>();
         
         let (out, mut overflow) = a.overflowing_mul(b);
         let mut out = out.to_integer();


### PR DESCRIPTION
## Motivation

`overflowing_mul`'s schoolbook accumulates each partial product in a **`u128`** digit (`to_digits::<u128>()` in `src/integer/overflowing.rs`). **wasm32 has no 128-bit multiply**, so every `u128` partial product lowers to a `__multi3` software libcall. In a wide-integer-heavy workload this is the dominant cost — profiling a downstream exact-arithmetic geometry kernel (which does `I256`/`I512` predicate math) found the `bnum` multiply path at ~66% of the wasm-vs-native gap, essentially all of it `__multi3`.

Splitting the operands into **`u32`** digits makes each partial product a single `u32 * u32 -> u64` (one `i64.mul` on wasm, no libcall).

## The change

One `cfg`-gated digit-width selection in the unsigned branch of `overflowing_mul`:

```rust
#[cfg(target_arch = "wasm32")]
type MulDigit = u32;
#[cfg(not(target_arch = "wasm32"))]
type MulDigit = u128;
let a = self.to_digits::<MulDigit>();
let b = rhs.to_digits::<MulDigit>();
```

**Off wasm32 the behavior and codegen are unchanged** (`u128`, which has a hardware 128-bit multiply). Only wasm32 changes path.

## Why it's identical, not just close

`to_digits::<D>` reinterprets the same N-byte two's-complement operand; the schoolbook then multiplies the same integers. The low-N-byte product — and whether the true product overflows the signed/unsigned width — is a property of the true product, independent of the accumulation digit width. So `MulDigit = u32` and `MulDigit = u128` return the identical `(wrapped value, overflow)` pair.

## Verification

- `cargo test` `mul` suite passes unchanged on native (the `u128` path is untouched): 144 passed.
- `cargo build --target wasm32-unknown-unknown` compiles clean.
- In the downstream kernel, a differential test proved independent u32-digit and u64-digit schoolbooks agree with each other **and** with `bnum::checked_mul` (value + overflow) over a random + adversarial boundary corpus for `I256`/`I512`/`I1024`/`I2048`.
- End-to-end on the real wasm target: **byte-identical** output (mesh position/index/normal checksums unchanged) with a measured **~9%** total speedup on a CSG-dense workload.

Happy to adjust the approach if you'd prefer a different way to select the digit width (e.g. a smaller `MulDigit` on all no-`u128`-mul targets rather than gating on `wasm32` specifically). Thanks for `bnum`!